### PR TITLE
fix: add types for cjs file

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -1,0 +1,23 @@
+export function resolve(
+  importer: string,
+  importee: string,
+  options?: Partial<{
+    mainFields: string[];
+    exportConditions: string[];
+    extensions: string[];
+  }>
+): string;
+export function count_module_graph_size(
+  entryPoints: string[] | string,
+  options?: Partial<{
+    basePath: string;
+    exportConditions: string[];
+    mainFields: string[];
+    extensions: string[];
+    alias?: Array<[string, string | null | undefined]> | Record<string, Array<string | null | undefined>>;
+  }>
+): number;
+export function is_barrel_file(
+  source: string,
+  amountOfExportsToConsiderModuleAsBarrel: number
+): boolean


### PR DESCRIPTION
This adds types for `index.cjs` which currently fails to resolve since `index.d.ts` is for the `index.js`.


@thepassle im doing this as a stepping stone for migrating the ESLint plugin into eslint-plugin-import-x. we can't build because the types are missing, and we can't import using a bare specifier since `index.js` exports different shaped functions to `index.cjs`

it seems like `index.d.ts` is the types for `index.js`,and `index.cjs` has different functions and no types. im not sure how these are generated though so let me know if there's a better way to fix this